### PR TITLE
feat(checksums): Add checksum for Erlang 28.0.2

### DIFF
--- a/data/erlang.json
+++ b/data/erlang.json
@@ -120,5 +120,6 @@
   "27.3.4": "0aadwh3mqn0y2h8wsg18p2hvyb76dh5s0klca4824z9rp7bqv625",
   "27.3.4.1": "0ms2y93n0bnxw6a3jazf7pyslyz963fppr7bkg6j4kxmsdqn1m9g",
   "28.0": "06294x2y8x245v78xp6z035crpdhy248drxc0hjgblm9nghl78v6",
-  "28.0.1": "1giajqrz1h8mi3n59q6d56djl3d5hvdm9b5yk98v9bx3x2nw6q3r"
+  "28.0.1": "1giajqrz1h8mi3n59q6d56djl3d5hvdm9b5yk98v9bx3x2nw6q3r",
+  "28.0.2": "0hqljgbhw7yx9hbpd2k0sdvr1psp4aq56wn3d8qa1q0pqpn6zqp3"
 }


### PR DESCRIPTION
Thanks for taking over this repository. I ran `just add-erlang 28.0.2` to add the latest OTP version. I hope that is ok.