### PR TITLE
fix: extend beamPackages to ensure consistent elixir

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -95,8 +95,10 @@
     pkgs,
   }: let
     erlang = mkErlang pkgs erlangVersion versions.erlang.${erlangVersion};
-    beamPkgs = pkgs.beam.packagesWith erlang;
-    elixir = mkElixir beamPkgs elixirVersion versions.elixir.${elixirVersion};
+    beamPkgs = (pkgs.beam.packagesWith erlang).extend (_: _: {
+      elixir = mkElixir beamPkgs elixirVersion versions.elixir.${elixirVersion};
+    });
+    inherit (beamPkgs) elixir;
   in
     {
       inherit (beamPkgs) erlang;


### PR DESCRIPTION
GitHub makes it awkward to open against the fork. :/

Anyway, this ensures all beamPackages use the desired/same version of elixir. In practice it's not usually a problem, but this is safer.