### PR TITLE
Revert "fix: don't enable elixir and erlang language servers by default"

### DIFF
--- a/parts/config.nix
+++ b/parts/config.nix
@@ -85,8 +85,8 @@ in {
           inherit pkgs;
           elixirVersion = beam-flakes-lib.normalizeElixir cfg.versions.elixir;
           erlangVersion = cfg.versions.erlang;
-          elixirLanguageServer = false;
-          erlangLanguageServer = false;
+          elixirLanguageServer = true;
+          erlangLanguageServer = true;
         };
       in {
         inherit (pkgset) elixir erlang elixir-ls erlang-ls;


### PR DESCRIPTION
This reverts commit 8190f08ffaac7faee1fb89301f2d228c31a51b14.

Fixes #6.